### PR TITLE
Add per-channel histogram array

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "CIImageHistogram",
+    platforms: [
+        .iOS("16.2"),
+        .macOS("12.0")
+    ],
+    products: [
+        .library(
+            name: "CIImageHistogram",
+            type: .dynamic,
+            targets: ["CIImageHistogram"])
+    ],
+    targets: [
+        .target(
+            name: "CIImageHistogram",
+            path: "Sources"
+        ),
+        .testTarget(
+            name: "CIImageHistogramTests",
+            dependencies: ["CIImageHistogram"],
+            path: "Tests"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # CIImageHistogram
+
+A Swift Package that provides utilities for calculating RGB histograms of a `CIImage`. The library supports images with high dynamic range values up to 16 and builds as a dynamic library for both iOS (16.2+) and macOS (12.0+).
+
+## Usage
+
+Add the package as a dependency in your `Package.swift`:
+
+```swift
+.package(url: "https://example.com/CIImageHistogram.git", from: "1.0.0")
+```
+
+Import the library and compute a histogram:
+
+```swift
+import CIImageHistogram
+import CoreImage
+
+let image = CIImage(contentsOf: url)!
+let rgbHist = CIImageHistogram.histogram(for: image, bins: 256)
+let redBins = rgbHist[0]
+```
+
+The resulting value is a 2D array where the first dimension corresponds to the red, green and blue channels. Each sub array contains the count of pixels in each bin from 0 to the provided `maxPixelValue` (default is 16).
+

--- a/Sources/CIImageHistogram/CIImageHistogram.swift
+++ b/Sources/CIImageHistogram/CIImageHistogram.swift
@@ -1,0 +1,57 @@
+import CoreImage
+import Accelerate
+
+public struct CIImageHistogram {
+    /// Computes the RGB histograms of a CIImage.
+    /// - Parameters:
+    ///   - image: Source CIImage.
+    ///   - bins: Number of histogram bins.
+    ///   - maxPixelValue: Maximum possible pixel intensity value. Defaults to 16 for HDR images.
+    ///   - context: Optional CIContext. Defaults to a new context.
+    /// - Returns: A 2D array where the first dimension represents color
+    ///   channels `[R, G, B]` and each sub array contains `bins` histogram
+    ///   counts for that channel.
+    public static func histogram(
+        for image: CIImage,
+        bins: Int = 256,
+        maxPixelValue: Float = 16,
+        context: CIContext = CIContext(options: nil)
+    ) -> [[Float]] {
+        let extent = image.extent.integral
+        guard !extent.isEmpty, bins > 0 else { return [] }
+
+        let width = Int(extent.width)
+        let height = Int(extent.height)
+        let pixels = width * height
+        var buffer = [Float](repeating: 0, count: pixels * 4)
+
+        context.render(
+            image,
+            toBitmap: &buffer,
+            rowBytes: width * MemoryLayout<Float>.size * 4,
+            bounds: extent,
+            format: .RGBAf,
+            colorSpace: CGColorSpaceCreateDeviceRGB()
+        )
+
+        var rHist = [Float](repeating: 0, count: bins)
+        var gHist = [Float](repeating: 0, count: bins)
+        var bHist = [Float](repeating: 0, count: bins)
+        let binFactor = Float(bins - 1) / maxPixelValue
+        for i in stride(from: 0, to: buffer.count, by: 4) {
+            let r = buffer[i]
+            let g = buffer[i + 1]
+            let b = buffer[i + 2]
+            let clampedR = max(0, min(maxPixelValue, r))
+            let clampedG = max(0, min(maxPixelValue, g))
+            let clampedB = max(0, min(maxPixelValue, b))
+            let rIndex = Int(clampedR * binFactor)
+            let gIndex = Int(clampedG * binFactor)
+            let bIndex = Int(clampedB * binFactor)
+            rHist[rIndex] += 1
+            gHist[gIndex] += 1
+            bHist[bIndex] += 1
+        }
+        return [rHist, gHist, bHist]
+    }
+}

--- a/Tests/CIImageHistogramTests/CIImageHistogramTests.swift
+++ b/Tests/CIImageHistogramTests/CIImageHistogramTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+import CoreImage
+@testable import CIImageHistogram
+
+final class CIImageHistogramTests: XCTestCase {
+    func testHistogramContainsPixelCount() {
+        let width = 2
+        let height = 2
+        let pixels: [Float] = [
+            0, 0, 0, 1,
+            1, 1, 1, 1,
+            2, 2, 2, 1,
+            3, 3, 3, 1
+        ]
+        let data = Data(bytes: pixels, count: pixels.count * MemoryLayout<Float>.size)
+        let bitmap = CIImage(bitmapData: data,
+                             bytesPerRow: width * 4 * MemoryLayout<Float>.size,
+                             size: CGSize(width: width, height: height),
+                             format: .RGBAf,
+                             colorSpace: CGColorSpaceCreateDeviceRGB())
+        let histogram = CIImageHistogram.histogram(for: bitmap, bins: 4, maxPixelValue: 3)
+        XCTAssertEqual(histogram.count, 3)
+        for channel in histogram {
+            XCTAssertEqual(channel, [1, 1, 1, 1])
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- return RGB histograms separately
- document 2D histogram result
- update unit tests for per-channel data

## Testing
- `swift build` *(fails: no such module 'CoreImage')*
- `swift test` *(fails: no such module 'CoreImage')*

------
https://chatgpt.com/codex/tasks/task_e_684411764c7c832c8ae0068c6d570b33