### PR TITLE
Fix potential headroom property

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,33 @@ let redBins = rgbHist[0]
 
 The resulting value is a 2D array where the first dimension corresponds to the red, green and blue channels. Each sub array contains the count of pixels in each bin from 0 to the provided `maxPixelValue` (default is 16).
 
+## Displaying a Histogram
+
+`HistogramLayer` is a `CALayer` subclass included in the package that draws the RGB histogram for a `CIImage`. The example below downloads an image from the internet and shows how to display its histogram:
+
+```swift
+import CIImageHistogram
+import CoreImage
+
+let url = URL(string: "https://upload.wikimedia.org/wikipedia/commons/3/3c/Shaki_waterfall.jpg")!
+let data = try Data(contentsOf: url)
+let ciImage = CIImage(data: data)!
+
+let layer = HistogramLayer()
+layer.frame = CGRect(x: 0, y: 0, width: 300, height: 200)
+layer.image = ciImage
+```
+
+Add the layer to your view's layer hierarchy to visualize the histogram.
+
+On displays that support Extended Dynamic Range (EDR), `HistogramLayer` draws an
+additional indicator on the right half of the view. A red overlay means no extra
+headroom is available. When EDR headroom is present, a white overlay appears and
+its width shrinks as the current headroom increases.
+
+On iOS, the layer uses `UIScreen`'s `potentialEDRHeadroom` and
+`currentEDRHeadroom` APIs (falling back to the older extended-dynamic-range
+properties on earlier releases) to determine available headroom. macOS exposes
+similar information via `NSScreen` using the matching EDR headroom properties or
+the legacy `maximumPotentialExtendedDynamicRangeColorComponentValue`.
+

--- a/Sources/CIImageHistogram/HistogramLayer.swift
+++ b/Sources/CIImageHistogram/HistogramLayer.swift
@@ -1,0 +1,158 @@
+import QuartzCore
+import CoreImage
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+
+/// A CALayer subclass that draws an RGB histogram for a given `CIImage` using
+/// `CIImageHistogram`.
+public class HistogramLayer: CALayer {
+    /// Image for which to draw the histogram. Setting this triggers a redraw.
+    public var image: CIImage? {
+        didSet { setNeedsDisplay() }
+    }
+
+    /// Number of histogram bins. Defaults to 256.
+    public var bins: Int = 256 {
+        didSet { setNeedsDisplay() }
+    }
+
+    /// Maximum pixel value used when computing the histogram. Defaults to 16.
+    public var maxPixelValue: Float = 16 {
+        didSet { setNeedsDisplay() }
+    }
+
+    /// Colors used for the RGB channels.
+    public var channelColors: [CGColor] = [
+        CGColor(red: 1, green: 0, blue: 0, alpha: 1),
+        CGColor(red: 0, green: 1, blue: 0, alpha: 1),
+        CGColor(red: 0, green: 0, blue: 1, alpha: 1)
+    ] {
+        didSet { setNeedsDisplay() }
+    }
+
+    /// Returns the screen's potential EDR headroom.
+    private var potentialHeadroom: CGFloat {
+#if os(iOS) || os(tvOS)
+        if #available(iOS 17.0, tvOS 17.0, *) {
+            return UIScreen.main.potentialEDRHeadroom
+        } else if #available(iOS 16.0, tvOS 16.0, *) {
+            return UIScreen.main.maximumExtendedDynamicRangeColorComponentValue
+        } else {
+            return 1
+        }
+#elseif os(macOS)
+        if #available(macOS 14.0, *) {
+            return NSScreen.main?.potentialEDRHeadroom ?? 1
+        } else if #available(macOS 12.0, *) {
+            return NSScreen.main?.maximumPotentialExtendedDynamicRangeColorComponentValue ?? 1
+        } else {
+            return 1
+        }
+#else
+        return 1
+#endif
+    }
+
+    /// Returns the screen's current EDR headroom.
+    private var currentHeadroom: CGFloat {
+#if os(iOS) || os(tvOS)
+        if #available(iOS 17.0, tvOS 17.0, *) {
+            return UIScreen.main.currentEDRHeadroom
+        } else if #available(iOS 16.0, tvOS 16.0, *) {
+            return UIScreen.main.currentExtendedDynamicRangeColorComponentValue
+        } else {
+            return 1
+        }
+#elseif os(macOS)
+        if #available(macOS 14.0, *) {
+            return NSScreen.main?.currentEDRHeadroom ?? 1
+        } else if #available(macOS 12.0, *) {
+            return NSScreen.main?.currentExtendedDynamicRangeColorComponentValue ?? 1
+        } else {
+            return 1
+        }
+#else
+        return 1
+#endif
+    }
+
+    public override init() {
+        super.init()
+        needsDisplayOnBoundsChange = true
+#if os(iOS) || os(tvOS)
+        contentsScale = UIScreen.main.scale
+#elseif os(macOS)
+        contentsScale = NSScreen.main?.backingScaleFactor ?? 2.0
+#endif
+    }
+
+    public override init(layer: Any) {
+        super.init(layer: layer)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        needsDisplayOnBoundsChange = true
+#if os(iOS) || os(tvOS)
+        contentsScale = UIScreen.main.scale
+#elseif os(macOS)
+        contentsScale = NSScreen.main?.backingScaleFactor ?? 2.0
+#endif
+    }
+
+    public override func draw(in ctx: CGContext) {
+        super.draw(in: ctx)
+        guard
+            let image = image,
+            bins > 0,
+            bounds.width > 0,
+            bounds.height > 0
+        else { return }
+
+        let histogram = CIImageHistogram.histogram(
+            for: image,
+            bins: bins,
+            maxPixelValue: maxPixelValue
+        )
+
+        ctx.saveGState()
+        ctx.setLineWidth(max(1, bounds.width / CGFloat(bins)))
+
+        for (channelIndex, binsData) in histogram.enumerated() where channelIndex < channelColors.count {
+            let maxCount = binsData.max() ?? 1
+            let xStep = bounds.width / CGFloat(binsData.count)
+            ctx.setStrokeColor(channelColors[channelIndex])
+            ctx.beginPath()
+            for (i, count) in binsData.enumerated() {
+                let x = CGFloat(i) * xStep + xStep / 2
+                let normalized = CGFloat(count) / CGFloat(maxCount)
+                let y = normalized * bounds.height
+                if i == 0 {
+                    ctx.move(to: CGPoint(x: x, y: 0))
+                }
+                ctx.addLine(to: CGPoint(x: x, y: y))
+            }
+            ctx.strokePath()
+        }
+        ctx.restoreGState()
+
+        // Draw headroom indicator on the right half of the histogram.
+        ctx.saveGState()
+        let halfWidth = bounds.width / 2
+        let indicatorRect: CGRect
+        if potentialHeadroom <= 1 {
+            ctx.setFillColor(red: 1, green: 0, blue: 0, alpha: 0.5)
+            indicatorRect = CGRect(x: bounds.midX, y: 0, width: halfWidth, height: bounds.height)
+        } else {
+            let normalized = max(1, min(8, currentHeadroom))
+            let width = halfWidth / normalized
+            ctx.setFillColor(gray: 1, alpha: 0.5)
+            indicatorRect = CGRect(x: bounds.maxX - width, y: 0, width: width, height: bounds.height)
+        }
+        ctx.fill(indicatorRect)
+        ctx.restoreGState()
+    }
+}


### PR DESCRIPTION
## Summary
- clarify property names used for calculating extended dynamic range headroom
- use `maximumExtendedDynamicRangeColorComponentValue` on iOS instead of the macOS-only property
- use new `potentialEDRHeadroom` and `currentEDRHeadroom` APIs when available

## Testing
- `swift test` *(fails: no such module 'CoreImage')*

------
https://chatgpt.com/codex/tasks/task_e_6844186c1478832cb7084426e5a5a27a